### PR TITLE
Added help text for `amount` during checkout create/update

### DIFF
--- a/src/models/components/checkoutcreate.ts
+++ b/src/models/components/checkoutcreate.ts
@@ -64,6 +64,9 @@ export type CheckoutCreate = {
    * Whether to require the customer to fill their full billing address, instead of just the country. Customers in the US will always be required to fill their full address, regardless of this setting. If you preset the billing address, this setting will be automatically set to `true`.
    */
   requireBillingAddress?: boolean | undefined;
+  /**
+   * Amount in cents, before discounts and taxes.
+   */
   amount?: number | null | undefined;
   /**
    * ID of an existing customer in the organization. The customer data will be pre-filled in the checkout form. The resulting order will be linked to this customer.

--- a/src/models/components/checkoutupdate.ts
+++ b/src/models/components/checkoutupdate.ts
@@ -40,6 +40,9 @@ export type CheckoutUpdate = {
    * @deprecated field: This will be removed in a future release, please migrate away from it as soon as possible.
    */
   productPriceId?: string | null | undefined;
+  /**
+   * Amount in cents, before discounts and taxes.
+   */
   amount?: number | null | undefined;
   customerName?: string | null | undefined;
   customerEmail?: string | null | undefined;


### PR DESCRIPTION
When using the SDK to create Checkout Sessions, all fields but `amount` have a textual description.

Even though `amount` is somewhat self-explanatory, it's not obvious that it **should be sent in cents instead of full dollars**. Also, the **only** example on [the docs](https://docs.polar.sh/features/checkout/session#sdk-examples) doesn't make use of it.

![image](https://github.com/user-attachments/assets/415fa6a1-85d2-4d5a-8d73-964b9bf8360c)
![image](https://github.com/user-attachments/assets/ffce5c6f-4cab-41ea-b22c-0a7a37fdb657)

This PR adds a short description to `amount` (copied from `/models/components/checkout.ts`) to both create() and update() flows. 