### PR TITLE
fix const fields always appearing optional

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -60,3 +60,4 @@ typescript:
   responseFormat: flat
   templateVersion: v2
   useIndexModules: false
+  constFieldsAlwaysOptional: false


### PR DESCRIPTION
You will need to regenerate or wait for the nightly built to regenerate for the changes to the SDK to appear.