### PR TITLE
Pin `speakeasy` version in SDK generation action

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -26,7 +26,7 @@ jobs:
             force: ${{ github.event.inputs.force }}
             mode: pr
             set_version: ${{ github.event.inputs.set_version }}
-            speakeasy_version: latest
+            speakeasy_version: 1.561.0
             target: ${{ github.event.inputs.target }}
         secrets:
             github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This SDK call:

```ts
const checkout = await polar.checkouts.create({
  products: [productId],
  successUrl: process.env.POLAR_SUCCESS_URL,
});
```

Results in this error:

```
ResponseValidationError: Response validation failed
    at safeParseResponse (/Users/ivov/Development/polar-test-project/node_modules/@polar-sh/sdk/dist/commonjs/lib/matchers.js:210:33)
    at matchFunc (/Users/ivov/Development/polar-test-project/node_modules/@polar-sh/sdk/dist/commonjs/lib/matchers.js:187:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async $do (/Users/ivov/Development/polar-test-project/node_modules/@polar-sh/sdk/dist/commonjs/funcs/checkoutsCreate.js:105:22) 
```

Looks like `zod` in the SDK throws when validating the checkout creation response from the Polar API, even though it succeeded with 201. 

This SDK is being generated from Polar's OpenAPI spec by `speakeasy` which was [pinned](https://github.com/polarsource/polar-js/commit/0d6ccbc62cd6ebe3e8e83bc13763e101b5681e2c) to 1.561.0, but the `sdk_generation.yml` GitHub action is still using `latest` so [this run](https://github.com/polarsource/polar-js/actions/runs/15994176862/job/45113697974#step:9:8) two weeks ago ended up using 1.573.0, which took precedence over the pinned version and brought back the union discrimination bug. 

I cannot quite find the bug in the `speakeasy` issues, but from the diff in the pinning PR, it seems that `speakeasy` generates Zod schemas that define the same discriminator field twice for union types, leading to the validation error.

Possibly related: https://github.com/polarsource/polar/issues/6152