### PR TITLE
refactor: centralize default HTTP retry codes via DEFAULT_RETRY_CODES

### DIFF
--- a/src/funcs/benefitsCreate.ts
+++ b/src/funcs/benefitsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/benefitsDelete.ts
+++ b/src/funcs/benefitsDelete.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -142,7 +142,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/benefitsGet.ts
+++ b/src/funcs/benefitsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/benefitsGrants.ts
+++ b/src/funcs/benefitsGrants.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -155,7 +155,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/benefitsList.ts
+++ b/src/funcs/benefitsList.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -151,7 +151,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/benefitsUpdate.ts
+++ b/src/funcs/benefitsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -136,7 +136,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutLinksCreate.ts
+++ b/src/funcs/checkoutLinksCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -124,7 +124,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutLinksDelete.ts
+++ b/src/funcs/checkoutLinksDelete.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutLinksGet.ts
+++ b/src/funcs/checkoutLinksGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutLinksList.ts
+++ b/src/funcs/checkoutLinksList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -141,7 +141,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutLinksUpdate.ts
+++ b/src/funcs/checkoutLinksUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -138,7 +138,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutsClientConfirm.ts
+++ b/src/funcs/checkoutsClientConfirm.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -158,7 +158,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutsClientGet.ts
+++ b/src/funcs/checkoutsClientGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   CheckoutPublic,
@@ -134,7 +134,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutsClientUpdate.ts
+++ b/src/funcs/checkoutsClientUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   CheckoutPublic,
@@ -143,7 +143,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutsCreate.ts
+++ b/src/funcs/checkoutsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutsGet.ts
+++ b/src/funcs/checkoutsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutsList.ts
+++ b/src/funcs/checkoutsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -144,7 +144,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/checkoutsUpdate.ts
+++ b/src/funcs/checkoutsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -142,7 +142,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customFieldsCreate.ts
+++ b/src/funcs/customFieldsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customFieldsDelete.ts
+++ b/src/funcs/customFieldsDelete.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customFieldsGet.ts
+++ b/src/funcs/customFieldsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customFieldsList.ts
+++ b/src/funcs/customFieldsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -142,7 +142,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customFieldsUpdate.ts
+++ b/src/funcs/customFieldsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -136,7 +136,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerMetersGet.ts
+++ b/src/funcs/customerMetersGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerMetersList.ts
+++ b/src/funcs/customerMetersList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -143,7 +143,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalBenefitGrantsGet.ts
+++ b/src/funcs/customerPortalBenefitGrantsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -148,7 +148,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalBenefitGrantsList.ts
+++ b/src/funcs/customerPortalBenefitGrantsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -156,7 +156,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalBenefitGrantsUpdate.ts
+++ b/src/funcs/customerPortalBenefitGrantsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -157,7 +157,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalCustomerMetersGet.ts
+++ b/src/funcs/customerPortalCustomerMetersGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -146,7 +146,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalCustomerMetersList.ts
+++ b/src/funcs/customerPortalCustomerMetersList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -152,7 +152,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalCustomersAddPaymentMethod.ts
+++ b/src/funcs/customerPortalCustomersAddPaymentMethod.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -133,7 +133,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalCustomersDeletePaymentMethod.ts
+++ b/src/funcs/customerPortalCustomersDeletePaymentMethod.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -147,7 +147,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalCustomersGet.ts
+++ b/src/funcs/customerPortalCustomersGet.ts
@@ -5,7 +5,7 @@
 import { PolarCore } from "../core.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -106,7 +106,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalCustomersListPaymentMethods.ts
+++ b/src/funcs/customerPortalCustomersListPaymentMethods.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -151,7 +151,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalCustomersUpdate.ts
+++ b/src/funcs/customerPortalCustomersUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -133,7 +133,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalDownloadablesList.ts
+++ b/src/funcs/customerPortalDownloadablesList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -149,7 +149,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalLicenseKeysActivate.ts
+++ b/src/funcs/customerPortalLicenseKeysActivate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   LicenseKeyActivate,
@@ -133,7 +133,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalLicenseKeysDeactivate.ts
+++ b/src/funcs/customerPortalLicenseKeysDeactivate.ts
@@ -8,7 +8,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   LicenseKeyDeactivate,
@@ -124,7 +124,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalLicenseKeysGet.ts
+++ b/src/funcs/customerPortalLicenseKeysGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -145,7 +145,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalLicenseKeysList.ts
+++ b/src/funcs/customerPortalLicenseKeysList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -160,7 +160,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalLicenseKeysValidate.ts
+++ b/src/funcs/customerPortalLicenseKeysValidate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   LicenseKeyValidate,
@@ -127,7 +127,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrdersConfirmRetryPayment.ts
+++ b/src/funcs/customerPortalOrdersConfirmRetryPayment.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -159,7 +159,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrdersGenerateInvoice.ts
+++ b/src/funcs/customerPortalOrdersGenerateInvoice.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -145,7 +145,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrdersGet.ts
+++ b/src/funcs/customerPortalOrdersGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -145,7 +145,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrdersGetPaymentStatus.ts
+++ b/src/funcs/customerPortalOrdersGetPaymentStatus.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -148,7 +148,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrdersInvoice.ts
+++ b/src/funcs/customerPortalOrdersInvoice.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -147,7 +147,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrdersList.ts
+++ b/src/funcs/customerPortalOrdersList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -154,7 +154,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrdersUpdate.ts
+++ b/src/funcs/customerPortalOrdersUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -148,7 +148,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalOrganizationsGet.ts
+++ b/src/funcs/customerPortalOrganizationsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   CustomerOrganization,
@@ -131,7 +131,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalSubscriptionsCancel.ts
+++ b/src/funcs/customerPortalSubscriptionsCancel.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -152,7 +152,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalSubscriptionsGet.ts
+++ b/src/funcs/customerPortalSubscriptionsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -146,7 +146,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalSubscriptionsList.ts
+++ b/src/funcs/customerPortalSubscriptionsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -154,7 +154,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerPortalSubscriptionsUpdate.ts
+++ b/src/funcs/customerPortalSubscriptionsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { resolveSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -155,7 +155,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customerSessionsCreate.ts
+++ b/src/funcs/customerSessionsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -124,7 +124,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersCreate.ts
+++ b/src/funcs/customersCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersDelete.ts
+++ b/src/funcs/customersDelete.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -144,7 +144,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersDeleteExternal.ts
+++ b/src/funcs/customersDeleteExternal.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -134,7 +134,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersGet.ts
+++ b/src/funcs/customersGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersGetExternal.ts
+++ b/src/funcs/customersGetExternal.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersGetState.ts
+++ b/src/funcs/customersGetState.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -141,7 +141,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersGetStateExternal.ts
+++ b/src/funcs/customersGetStateExternal.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -143,7 +143,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersList.ts
+++ b/src/funcs/customersList.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -151,7 +151,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersUpdate.ts
+++ b/src/funcs/customersUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -136,7 +136,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/customersUpdateExternal.ts
+++ b/src/funcs/customersUpdateExternal.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -138,7 +138,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/discountsCreate.ts
+++ b/src/funcs/discountsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/discountsDelete.ts
+++ b/src/funcs/discountsDelete.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/discountsGet.ts
+++ b/src/funcs/discountsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/discountsList.ts
+++ b/src/funcs/discountsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -141,7 +141,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/discountsUpdate.ts
+++ b/src/funcs/discountsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -136,7 +136,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/eventsGet.ts
+++ b/src/funcs/eventsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import { Event, Event$inboundSchema } from "../models/components/event.js";
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/eventsIngest.ts
+++ b/src/funcs/eventsIngest.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/eventsList.ts
+++ b/src/funcs/eventsList.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -157,7 +157,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/eventsListNames.ts
+++ b/src/funcs/eventsListNames.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -144,7 +144,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/filesCreate.ts
+++ b/src/funcs/filesCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/filesDelete.ts
+++ b/src/funcs/filesDelete.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -138,7 +138,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/filesList.ts
+++ b/src/funcs/filesList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -140,7 +140,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/filesUpdate.ts
+++ b/src/funcs/filesUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -140,7 +140,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/filesUploaded.ts
+++ b/src/funcs/filesUploaded.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -142,7 +142,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/licenseKeysActivate.ts
+++ b/src/funcs/licenseKeysActivate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/licenseKeysDeactivate.ts
+++ b/src/funcs/licenseKeysDeactivate.ts
@@ -8,7 +8,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -126,7 +126,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/licenseKeysGet.ts
+++ b/src/funcs/licenseKeysGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -141,7 +141,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/licenseKeysGetActivation.ts
+++ b/src/funcs/licenseKeysGetActivation.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -147,7 +147,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/licenseKeysList.ts
+++ b/src/funcs/licenseKeysList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -152,7 +152,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/licenseKeysUpdate.ts
+++ b/src/funcs/licenseKeysUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -142,7 +142,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/licenseKeysValidate.ts
+++ b/src/funcs/licenseKeysValidate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -129,7 +129,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/metersCreate.ts
+++ b/src/funcs/metersCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import { Meter, Meter$inboundSchema } from "../models/components/meter.js";
@@ -120,7 +120,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/metersGet.ts
+++ b/src/funcs/metersGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import { Meter, Meter$inboundSchema } from "../models/components/meter.js";
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/metersList.ts
+++ b/src/funcs/metersList.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -150,7 +150,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/metersQuantities.ts
+++ b/src/funcs/metersQuantities.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -153,7 +153,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/metersUpdate.ts
+++ b/src/funcs/metersUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import { Meter, Meter$inboundSchema } from "../models/components/meter.js";
@@ -133,7 +133,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/metricsGet.ts
+++ b/src/funcs/metricsGet.ts
@@ -7,7 +7,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/metricsLimits.ts
+++ b/src/funcs/metricsLimits.ts
@@ -5,7 +5,7 @@
 import { PolarCore } from "../core.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -96,7 +96,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/oauth2Authorize.ts
+++ b/src/funcs/oauth2Authorize.ts
@@ -5,7 +5,7 @@
 import { PolarCore } from "../core.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -91,7 +91,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/oauth2Introspect.ts
+++ b/src/funcs/oauth2Introspect.ts
@@ -7,7 +7,7 @@ import { encodeBodyForm } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   IntrospectTokenRequest,
@@ -113,7 +113,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/oauth2Revoke.ts
+++ b/src/funcs/oauth2Revoke.ts
@@ -7,7 +7,7 @@ import { encodeBodyForm } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   RevokeTokenRequest,
@@ -113,7 +113,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/oauth2Token.ts
+++ b/src/funcs/oauth2Token.ts
@@ -7,7 +7,7 @@ import { encodeBodyForm } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { pathToFunc } from "../lib/url.js";
 import {
   TokenResponse,
@@ -113,7 +113,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/oauth2Userinfo.ts
+++ b/src/funcs/oauth2Userinfo.ts
@@ -5,7 +5,7 @@
 import { PolarCore } from "../core.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -94,7 +94,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/ordersGenerateInvoice.ts
+++ b/src/funcs/ordersGenerateInvoice.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/ordersGet.ts
+++ b/src/funcs/ordersGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import { Order, Order$inboundSchema } from "../models/components/order.js";
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/ordersInvoice.ts
+++ b/src/funcs/ordersInvoice.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/ordersList.ts
+++ b/src/funcs/ordersList.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -154,7 +154,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/ordersUpdate.ts
+++ b/src/funcs/ordersUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import { Order, Order$inboundSchema } from "../models/components/order.js";
@@ -133,7 +133,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/organizationsCreate.ts
+++ b/src/funcs/organizationsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/organizationsGet.ts
+++ b/src/funcs/organizationsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/organizationsList.ts
+++ b/src/funcs/organizationsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -140,7 +140,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/organizationsUpdate.ts
+++ b/src/funcs/organizationsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -144,7 +144,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/paymentsGet.ts
+++ b/src/funcs/paymentsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/paymentsList.ts
+++ b/src/funcs/paymentsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -145,7 +145,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/productsCreate.ts
+++ b/src/funcs/productsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/productsGet.ts
+++ b/src/funcs/productsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/productsList.ts
+++ b/src/funcs/productsList.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -154,7 +154,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/productsUpdate.ts
+++ b/src/funcs/productsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -142,7 +142,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/productsUpdateBenefits.ts
+++ b/src/funcs/productsUpdateBenefits.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -144,7 +144,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/refundsCreate.ts
+++ b/src/funcs/refundsCreate.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import { Refund, Refund$inboundSchema } from "../models/components/refund.js";
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/refundsList.ts
+++ b/src/funcs/refundsList.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -145,7 +145,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/subscriptionsExport.ts
+++ b/src/funcs/subscriptionsExport.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/subscriptionsGet.ts
+++ b/src/funcs/subscriptionsGet.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/subscriptionsList.ts
+++ b/src/funcs/subscriptionsList.ts
@@ -12,7 +12,7 @@ import {
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -154,7 +154,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/subscriptionsRevoke.ts
+++ b/src/funcs/subscriptionsRevoke.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -141,7 +141,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/subscriptionsUpdate.ts
+++ b/src/funcs/subscriptionsUpdate.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -144,7 +144,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksCreateWebhookEndpoint.ts
+++ b/src/funcs/webhooksCreateWebhookEndpoint.ts
@@ -7,7 +7,7 @@ import { encodeJSON } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -123,7 +123,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksDeleteWebhookEndpoint.ts
+++ b/src/funcs/webhooksDeleteWebhookEndpoint.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksGetWebhookEndpoint.ts
+++ b/src/funcs/webhooksGetWebhookEndpoint.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -135,7 +135,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksListWebhookDeliveries.ts
+++ b/src/funcs/webhooksListWebhookDeliveries.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -141,7 +141,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksListWebhookEndpoints.ts
+++ b/src/funcs/webhooksListWebhookEndpoints.ts
@@ -8,7 +8,7 @@ import { encodeFormQuery } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -139,7 +139,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksRedeliverWebhookEvent.ts
+++ b/src/funcs/webhooksRedeliverWebhookEvent.ts
@@ -8,7 +8,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -132,7 +132,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksResetWebhookEndpointSecret.ts
+++ b/src/funcs/webhooksResetWebhookEndpointSecret.ts
@@ -7,7 +7,7 @@ import { encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -136,7 +136,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/funcs/webhooksUpdateWebhookEndpoint.ts
+++ b/src/funcs/webhooksUpdateWebhookEndpoint.ts
@@ -7,7 +7,7 @@ import { encodeJSON, encodeSimple } from "../lib/encodings.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
 import { safeParse } from "../lib/schemas.js";
-import { RequestOptions } from "../lib/sdks.js";
+import { RequestOptions, DEFAULT_RETRY_CODES } from "../lib/sdks.js";
 import { extractSecurity, resolveGlobalSecurity } from "../lib/security.js";
 import { pathToFunc } from "../lib/url.js";
 import {
@@ -138,7 +138,7 @@ async function $do(
     retryConfig: options?.retries
       || client._options.retryConfig
       || { strategy: "none" },
-    retryCodes: options?.retryCodes || ["429", "500", "502", "503", "504"],
+    retryCodes: options?.retryCodes || DEFAULT_RETRY_CODES,
   };
 
   const requestRes = client._createRequest(context, {

--- a/src/lib/sdks.ts
+++ b/src/lib/sdks.ts
@@ -56,6 +56,8 @@ export type RequestOptions = {
   fetchOptions?: Omit<RequestInit, "method" | "body">;
 } & Omit<RequestInit, "method" | "body">;
 
+export const DEFAULT_RETRY_CODES: string[] = ["429", "500", "502", "503", "504"];
+
 type RequestConfig = {
   method: string;
   path: string;


### PR DESCRIPTION
- Centralize default retry codes with `DEFAULT_RETRY_CODES`  
- Replace hard-coded arrays across all funcs