### PR TITLE
events: Add custom code for event ingestion

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -51,7 +51,7 @@ typescript:
   clientServerStatusCodesAsErrors: true
   constFieldsAlwaysOptional: false
   defaultErrorName: SDKError
-  enableCustomCodeRegions: false
+  enableCustomCodeRegions: true
   enableMCPServer: false
   enableReactQuery: false
   enumFormat: union

--- a/src/sdk/events-custom.ts
+++ b/src/sdk/events-custom.ts
@@ -1,0 +1,39 @@
+import type { CostMetadataInput } from "../models/components/costmetadatainput.js";
+import type { EventMetadataInput } from "../models/components/eventmetadatainput.js";
+import type { EventsIngestResponse } from "../models/components/eventsingestresponse.js";
+import type { LLMMetadata } from "../models/components/llmmetadata.js";
+import type { RequestOptions } from "../lib/sdks.js";
+
+export type CustomerIdentifier =
+  | { externalCustomerId: string; customerId?: never }
+  | { customerId: string; externalCustomerId?: never };
+
+export type SendEventOptions = {
+  name: string;
+  externalId?: string;
+  parentId?: string;
+  cost?: CostMetadataInput;
+  llm?: LLMMetadata;
+  metadata?: Record<string, EventMetadataInput>;
+} & CustomerIdentifier;
+
+export type SpanEventOptions = {
+  name: string;
+  externalId?: string;
+  cost?: CostMetadataInput;
+  llm?: LLMMetadata;
+  metadata?: Record<string, EventMetadataInput>;
+};
+
+export type WithSpanOptions = {
+  name: string;
+  externalId: string;
+  metadata?: Record<string, EventMetadataInput>;
+} & CustomerIdentifier;
+
+export interface EventsSpanClient {
+  sendEvents(
+    events: Array<SpanEventOptions>,
+    requestOptions?: RequestOptions,
+  ): Promise<EventsIngestResponse>;
+}

--- a/src/sdk/events.ts
+++ b/src/sdk/events.ts
@@ -22,6 +22,23 @@ import {
 import { unwrapAsync } from "../types/fp.js";
 import { PageIterator, unwrapResultIterator } from "../types/operations.js";
 
+// #region imports
+import type { EventMetadataInput } from "../models/components/eventmetadatainput.js";
+import type {
+  EventsSpanClient,
+  SendEventOptions,
+  SpanEventOptions,
+  WithSpanOptions,
+} from "./events-custom.js";
+export type {
+  CustomerIdentifier,
+  EventsSpanClient,
+  SendEventOptions,
+  SpanEventOptions,
+  WithSpanOptions,
+} from "./events-custom.js";
+// #endregion imports
+
 export class Events extends ClientSDK {
   /**
    * List Events
@@ -98,4 +115,104 @@ export class Events extends ClientSDK {
       options,
     ));
   }
+
+  // #region sdk-class-body
+  private _enrichMetadata(
+    options: SpanEventOptions,
+  ): Record<string, EventMetadataInput> | undefined {
+    const metadata: Record<string, EventMetadataInput> = {
+      ...options.metadata,
+    };
+
+    if (options.cost) {
+      metadata["_cost"] = options.cost;
+    }
+    if (options.llm) {
+      metadata["_llm"] = options.llm;
+    }
+
+    return Object.keys(metadata).length > 0 ? metadata : undefined;
+  }
+
+  async sendEvents(
+    events: Array<SendEventOptions>,
+    requestOptions?: RequestOptions,
+  ): Promise<EventsIngestResponse> {
+    const mapped = events.map((eventOpts) => {
+      const metadata = this._enrichMetadata(eventOpts);
+      if ("externalCustomerId" in eventOpts && eventOpts.externalCustomerId) {
+        return {
+          name: eventOpts.name,
+          externalId: eventOpts.externalId,
+          parentId: eventOpts.parentId,
+          metadata,
+          externalCustomerId: eventOpts.externalCustomerId,
+        };
+      }
+      return {
+        name: eventOpts.name,
+        externalId: eventOpts.externalId,
+        parentId: eventOpts.parentId,
+        metadata,
+        customerId: eventOpts.customerId!,
+      };
+    });
+
+    return this.ingest({ events: mapped }, requestOptions);
+  }
+
+  async withSpan(
+    options: WithSpanOptions,
+    requestOptions?: RequestOptions,
+  ): Promise<EventsSpanClient> {
+    const parentId = options.externalId;
+    const useExternalCustomer =
+      "externalCustomerId" in options && options.externalCustomerId;
+
+    const spanEvent = useExternalCustomer
+      ? {
+          name: options.name,
+          externalId: options.externalId,
+          metadata: options.metadata,
+          externalCustomerId: options.externalCustomerId,
+        }
+      : {
+          name: options.name,
+          externalId: options.externalId,
+          metadata: options.metadata,
+          customerId: options.customerId!,
+        };
+
+    await this.ingest({ events: [spanEvent] }, requestOptions);
+
+    return {
+      sendEvents: (
+        events: Array<SpanEventOptions>,
+        reqOptions?: RequestOptions,
+      ) => {
+        const enrichedEvents = events.map((eventOpts) => {
+          const metadata = this._enrichMetadata(eventOpts);
+          if (useExternalCustomer) {
+            return {
+              name: eventOpts.name,
+              externalId: eventOpts.externalId,
+              parentId,
+              metadata,
+              externalCustomerId: options.externalCustomerId,
+            };
+          }
+          return {
+            name: eventOpts.name,
+            externalId: eventOpts.externalId,
+            parentId,
+            metadata,
+            customerId: options.customerId!,
+          };
+        });
+
+        return this.ingest({ events: enrichedEvents }, reqOptions ?? requestOptions);
+      },
+    };
+  }
+  // #endregion sdk-class-body
 }


### PR DESCRIPTION
- Adds syntactic sugar to ingest costs and llm metadata
- Adds an easy way to ingest events and child-events (as spans)